### PR TITLE
Update tag_name to use github.ref_name

### DIFF
--- a/.github/workflows/release_apk.yml
+++ b/.github/workflows/release_apk.yml
@@ -51,7 +51,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
+        tag_name: ${{ github.ref_name }}
         draft: false
         prerelease: false
         files: app/build/outputs/apk/release/tryfox.apk


### PR DESCRIPTION
Instead of the release name being `refs/tags/v0.0.2`, let's make it `v0.0.2`. I think this is the right property from the list here: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context